### PR TITLE
Fix code scanning alert no. 1: Storage of sensitive information in build artifact

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -166,7 +166,10 @@ module.exports = {
       Buffer: ['buffer', 'Buffer']
     }),
     new webpack.DefinePlugin({
-      'process.env': JSON.stringify(process.env)
+      'process.env': JSON.stringify({
+        NODE_ENV: process.env.NODE_ENV,
+        TARGET_BROWSER: process.env.TARGET_BROWSER
+      })
     }),
     // write manifest.json
     new WriteWebpackPlugin([


### PR DESCRIPTION
Fixes [https://github.com/VersoriumX/bitpay-browser-extension/security/code-scanning/1](https://github.com/VersoriumX/bitpay-browser-extension/security/code-scanning/1)

To fix the problem, we should only include the environment variables that are meant to be public in the build artifact. This can be done by explicitly specifying which environment variables to include in the `webpack.DefinePlugin` configuration. In this case, we will include only the `NODE_ENV` and `TARGET_BROWSER` environment variables, which are already being used in the `webpack.EnvironmentPlugin`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
